### PR TITLE
feat: allow overiding `sharp.options`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,8 +13,11 @@ const defaults = {
     cleanCron: env('IPX_CACHE_CLEAN_CRON', '0 0 3 * * *'),
     maxUnusedMinutes: env('IPX_CACHE_CLEAN_MINUTES', 24 * 60)
   },
-  keepMetadata: false,
-  useExifOrientation: false
+  /**
+   * override sharp options
+   * https://github.com/lovell/sharp/blob/master/lib/constructor.js#L130
+   */
+  sharp: {}
 }
 export default function getConfig (options: Partial<IPXOptions>): IPXOptions {
   const config: IPXOptions = defu(options, defaults)

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,9 @@ const defaults = {
     dir: env('IPX_CACHE_DIR', 'cache'),
     cleanCron: env('IPX_CACHE_CLEAN_CRON', '0 0 3 * * *'),
     maxUnusedMinutes: env('IPX_CACHE_CLEAN_MINUTES', 24 * 60)
-  }
+  },
+  keepMetadata: false,
+  useExifOrientation: false
 }
 export default function getConfig (options: Partial<IPXOptions>): IPXOptions {
   const config: IPXOptions = defu(options, defaults)

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -180,6 +180,12 @@ class IPX {
     operations.forEach(({ operation, args }) => {
       sharp = operation.handler(context, sharp, ...args) || sharp
     })
+
+    /**
+     * auto-rotate image based on EXIF orientation tag
+     * see: https://github.com/lovell/sharp/blob/0ee08bfe46e0b204b34151fead8139027c768375/lib/operation.js#L41
+     */
+    sharp = sharp.rotate()
     return sharp
   }
 

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -181,13 +181,6 @@ class IPX {
       sharp = operation.handler(context, sharp, ...args) || sharp
     })
 
-    if (this.options.useExifOrientation) {
-      /**
-       * auto-rotate image based on EXIF orientation tag
-       * see: https://github.com/lovell/sharp/blob/0ee08bfe46e0b204b34151fead8139027c768375/lib/operation.js#L41
-       */
-      sharp = sharp.rotate()
-    }
     return sharp
   }
 
@@ -201,12 +194,10 @@ class IPX {
     // Read buffer from input
     let data = await this.get(info.src, info.adapter)
     let sharp = Sharp(data)
+    Object.assign((sharp as any).options, this.options.sharp)
 
     if (!this.skipOperations(info)) {
       sharp = this.applyOperations(sharp, info)
-      if (this.options.keepMetadata) {
-        sharp = sharp.withMetadata()
-      }
       data = await sharp.toBuffer()
     }
 

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -181,11 +181,13 @@ class IPX {
       sharp = operation.handler(context, sharp, ...args) || sharp
     })
 
-    /**
-     * auto-rotate image based on EXIF orientation tag
-     * see: https://github.com/lovell/sharp/blob/0ee08bfe46e0b204b34151fead8139027c768375/lib/operation.js#L41
-     */
-    sharp = sharp.rotate()
+    if (this.options.useExifOrientation) {
+      /**
+       * auto-rotate image based on EXIF orientation tag
+       * see: https://github.com/lovell/sharp/blob/0ee08bfe46e0b204b34151fead8139027c768375/lib/operation.js#L41
+       */
+      sharp = sharp.rotate()
+    }
     return sharp
   }
 
@@ -202,6 +204,9 @@ class IPX {
 
     if (!this.skipOperations(info)) {
       sharp = this.applyOperations(sharp, info)
+      if (this.options.keepMetadata) {
+        sharp = sharp.withMetadata()
+      }
       data = await sharp.toBuffer()
     }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -39,8 +39,9 @@ export interface IPXOptions {
     maxUnusedMinutes: number | string;
   },
   operations?: IPXOperations
-  keepMetadata?: boolean
-  useExifOrientation?: boolean
+  sharp?: {
+    [key: string]: any;
+  }
 }
 
 export interface IPXImage {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -39,6 +39,8 @@ export interface IPXOptions {
     maxUnusedMinutes: number | string;
   },
   operations?: IPXOperations
+  keepMetadata?: boolean
+  useExifOrientation?: boolean
 }
 
 export interface IPXImage {


### PR DESCRIPTION
Use `rotate` operation to auto-rotate image based on EXIF orientation TAG.  
Docs of rotate operation: https://github.com/lovell/sharp/blob/0ee08bfe46e0b204b34151fead8139027c768375/lib/operation.js#L41

fix https://github.com/nuxt/image/issues/70