### PR TITLE
fix: support `HttpAgent` with `remote` input

### DIFF
--- a/src/input/remote.ts
+++ b/src/input/remote.ts
@@ -1,17 +1,28 @@
+import http from 'http'
 import https from 'https'
 import { stat, Stats } from 'fs-extra'
 import fetch from 'node-fetch'
 import BaseInputAdapter from './BaseInputAdapter'
 
 export default class RemoteAdapter extends BaseInputAdapter {
-  agent?: https.Agent = undefined
+  httpsAgent?: https.Agent = undefined
+  httpAgent?: http.Agent = undefined
   init () {
-    this.agent = new https.Agent({
+    this.httpsAgent = new https.Agent({
+      // keepAliveMsecs: 1000, // default
+      // maxSockets: Infinity, // default
+      keepAlive: true
+    })
+    this.httpAgent = new http.Agent({
       // keepAliveMsecs: 1000, // default
       // maxSockets: Infinity, // default
       keepAlive: true
     })
     this.options.accept = this.options.accept || ['.*']
+  }
+
+  getAgent (src: string) {
+    return src.startsWith('https') ? this.httpsAgent : this.httpAgent
   }
 
   async _retrive (src: string) {
@@ -24,7 +35,7 @@ export default class RemoteAdapter extends BaseInputAdapter {
       }
     }
     const response = await fetch(src, {
-      agent: this.agent
+      agent: this.getAgent(src)
     })
     const buffer = await response.buffer()
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,11 +10,7 @@ async function IPXReqHandler (req: IncomingMessage, res: ServerResponse, ipx: IP
   const adapter = decodeURIComponent(urlArgs.shift() || '')
   const format = decodeURIComponent(urlArgs.shift() || '')
   const operations = decodeURIComponent(urlArgs.shift() || '')
-  let src = urlArgs.map(c => decodeURIComponent(c)).join('/')
-
-  if (adapter === 'remote' && !src.startsWith('http')) {
-    src = (req.headers.referer || req.headers.host || '') + src
-  }
+  const src = urlArgs.map(c => decodeURIComponent(c)).join('/')
 
   // Validate params
   if (!adapter) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,11 @@ async function IPXReqHandler (req: IncomingMessage, res: ServerResponse, ipx: IP
   const adapter = decodeURIComponent(urlArgs.shift() || '')
   const format = decodeURIComponent(urlArgs.shift() || '')
   const operations = decodeURIComponent(urlArgs.shift() || '')
-  const src = urlArgs.map(c => decodeURIComponent(c)).join('/')
+  let src = urlArgs.map(c => decodeURIComponent(c)).join('/')
+
+  if (adapter === 'remote' && !src.startsWith('http')) {
+    src = (req.headers.referer || req.headers.host || '') + src
+  }
 
   // Validate params
   if (!adapter) {


### PR DESCRIPTION
- Support http
- On remote adapters if url is relative we can request image referer or self host
Using this we can drop `local` adapter in NuxtImage without forcing user to enter baseURL