### PR TITLE
fix: prevent unknow format error

### DIFF
--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -13,6 +13,7 @@ import BaseCacheAdapter from './cache/BaseCacheAdapter'
 
 const operationSeparator = ','
 const argSeparator = '_'
+const unknownFormat = 'unknown'
 
 class IPX {
   options: IPXOptions
@@ -123,14 +124,15 @@ class IPX {
   async getInfo ({ adapter, format, operations, src }: IPXImage): Promise<IPXImageInfo> {
     // Validate format
     if (format === '_') {
-      const extension = extname(src).substr(1)
-      if (extension.match(/jpeg|webp|png|jpg|svg|gif/)) {
-        format = extension
-      }
+      format = extname(src).substr(1)
     }
 
-    if (!format.match(/jpeg|webp|png|jpg|svg|gif|_/)) {
-      throw badRequest(`Unkown image format ${format}`)
+    if (format === 'jpeg') {
+      format = 'jpg'
+    }
+
+    if (!format.match(/webp|png|jpg|svg|gif/)) {
+      format = unknownFormat
     }
 
     // Validate src
@@ -171,7 +173,7 @@ class IPX {
   }
 
   applyOperations (sharp: Sharp.Sharp, { operations, format }: IPXImageInfo): Sharp.Sharp {
-    if (format !== '_') {
+    if (format !== unknownFormat) {
       operations.push({
         operation: this.operations.format,
         args: [format]

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -123,10 +123,13 @@ class IPX {
   async getInfo ({ adapter, format, operations, src }: IPXImage): Promise<IPXImageInfo> {
     // Validate format
     if (format === '_') {
-      format = extname(src).substr(1)
+      const extension = extname(src).substr(1)
+      if (extension.match(/jpeg|webp|png|jpg|svg|gif/)) {
+        format = extension
+      }
     }
 
-    if (!format.match(/jpeg|webp|png|jpg|svg|gif/)) {
+    if (!format.match(/jpeg|webp|png|jpg|svg|gif|_/)) {
       throw badRequest(`Unkown image format ${format}`)
     }
 
@@ -171,7 +174,7 @@ class IPX {
     if (format !== '_') {
       operations.push({
         operation: this.operations.format,
-        args: [this.extractImageFormat(format)]
+        args: [format]
       })
     }
 
@@ -257,14 +260,6 @@ class IPX {
       default:
         return 'image/' + format
     }
-  }
-
-  private extractImageFormat (format) {
-    format = format.split('.').shift()
-    if (format === 'jpg') {
-      format = 'jpeg'
-    }
-    return format
   }
 
   private skipOperations (info: IPXImageInfo) {


### PR DESCRIPTION
Ensure extracted extension from URL is a valid format. Fallback to unknown if it isn't

fix #17 