### PR TITLE
fix: serialize src in cache adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "is-valid-path": "^0.1.1",
     "node-fetch": "^2.6.1",
     "recursive-readdir": "^2.2.2",
-    "sharp": "^0.27.0"
+    "sharp": "^0.27.0",
+    "shorthash2": "^1.0.3"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "latest",

--- a/src/input/remote.ts
+++ b/src/input/remote.ts
@@ -28,12 +28,11 @@ export default class RemoteAdapter extends BaseInputAdapter {
     return src.startsWith('https') ? this.httpsAgent : this.httpAgent
   }
 
-  async _retrive (src: string) {
-    const cacheKey = src.split(/[?#]/).shift()?.split('//').pop()!
-    const cache = await this.ipx.cache?.get(cacheKey)
+  async _retrieve (src: string) {
+    const cache = await this.ipx.cache?.get(src)
     if (cache) {
       return {
-        cache: await this.ipx.cache?.resolve(cacheKey),
+        cache: await this.ipx.cache?.resolve(src),
         buffer: cache
       }
     }
@@ -43,11 +42,11 @@ export default class RemoteAdapter extends BaseInputAdapter {
     const buffer = await response.buffer()
 
     if (this.ipx.cache) {
-      await this.ipx.cache.set(cacheKey, buffer)
+      await this.ipx.cache.set(src, buffer)
     }
 
     return {
-      cache: await this.ipx.cache?.resolve(cacheKey),
+      cache: await this.ipx.cache?.resolve(src),
       buffer
     }
   }
@@ -66,7 +65,7 @@ export default class RemoteAdapter extends BaseInputAdapter {
     if (!this.accept(src)) {
       return false
     }
-    const _src = await this._retrive(src)
+    const _src = await this._retrieve(src)
 
     try {
       const stats = await stat(_src.cache as string)
@@ -82,6 +81,6 @@ export default class RemoteAdapter extends BaseInputAdapter {
    * @returns Promise<Buffer>
    */
   async get (src: string) {
-    return (await this._retrive(src)).buffer
+    return (await this._retrieve(src)).buffer
   }
 };

--- a/src/input/remote.ts
+++ b/src/input/remote.ts
@@ -36,7 +36,9 @@ export default class RemoteAdapter extends BaseInputAdapter {
         buffer: cache
       }
     }
-    const response = await fetch(src, {
+    const [base, query] = src.split('?')
+    const url = base + (query ? '?' + encodeURI(query) : '')
+    const response = await fetch(url, {
       agent: this.getAgent(src)
     })
     const buffer = await response.buffer()

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -191,7 +191,7 @@ class IPX {
 
   async getData (info: IPXImageInfo) {
     // Check cache existence
-    const cache = await this.cache!.get(info.cacheKey)
+    const cache = await this.cache!.get(info.src)
     if (cache) {
       return cache
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3752,6 +3752,11 @@ shelljs@^0.8.3:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+shorthash2@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/shorthash2/-/shorthash2-1.0.3.tgz#fd05b1d8eefc72879c35f52db18d4b95250ce0a3"
+  integrity sha512-oB8s64JsyJ2xhHJlnTwGg++Y3BTF6XnXeXMC7OygD8vtNcCRDiMxEGONvUOeZbxfwEXENmRlqPDouMR/OtGDsw==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"


### PR DESCRIPTION
I found an issue with cacheKey of IPX when image depends of query parameters.

I am using https://eu.ui-avatars.com/ for avatars on Nuxt Image demo.

Example:
- https://eu.ui-avatars.com/api/?name=John+Doe
- https://eu.ui-avatars.com/api/?name=Seb+Chopin

The issue is that IPX will cache the first Image since we actually split with # or ?, see https://github.com/nuxt-contrib/ipx/blob/11d1e1aa86350a9f095a175844a09a0f9a6b598b/src/input/remote.ts#L32

This PR fixes it by moving the key generation in the cache adapter directly (should not create any issue for FS adapter), this way we also have the `cache` directory with only files inside and no sub directories.

I found [shorthash2](https://github.com/jecsham/shorthash2) quite nice, rewritten in TS with a simple implementation.